### PR TITLE
fix: Dockerfile add download patched glibc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,13 @@ ENV LANG="${SETLANG}.UTF-8"\
     LC_PAPER="${SETLANG}.UTF-8"\
     LC_MEASUREMENT="${SETLANG}.UTF-8"
 
+# WORKAROUND for glibc 2.33 and old Docker
+# See https://github.com/actions/virtual-environments/issues/2658
+# Thanks to https://github.com/lxqt/lxqt-panel/pull/1562
+RUN patched_glibc=glibc-linux4-2.33-4-x86_64.pkg.tar.zst && \
+    curl -LO "https://repo.archlinuxcn.org/x86_64/$patched_glibc" && \
+    bsdtar -C / -xvf "$patched_glibc"
+
 # Locale setting
 ARG GLIBVER="2.33"
 ARG LOCALETIME="Asia/Tokyo"


### PR DESCRIPTION
[Docker上でArchLinuxのパッチ済みglibcをDLする処理](https://github.com/qutebrowser/qutebrowser/commit/478e4de7bd1f26bebdcdc166d5369b2b5142c3e2)

